### PR TITLE
Add Avito interview tasks: merge sorted lists and port ranges

### DIFF
--- a/tasks/task0030.py
+++ b/tasks/task0030.py
@@ -1,0 +1,39 @@
+"""
+Avito: Merge two list
+
+Дано 2 отсортированных (по возрастанию) массива A и B длины M и N.
+Нужно слить их в один отсортированный (по возрастанию) массив,
+состоящий из элементов первых двух.
+
+Ввод:
+- a = [1, 2, 5]
+- b = [1, 2, 3, 4, 6]
+
+Вывод:
+- [1, 1, 2, 2, 3, 4, 5, 6]
+
+Оценка:
+- M, N - длины массивов A и B
+- Оценка по времени - O(M + N)
+- Оценка по памяти - O(M + N)
+"""
+
+from typing import List
+
+
+def solution(a: List[int], b: List[int]) -> List[int]:
+    i, j = 0, 0
+    result: List[int] = []
+
+    while i < len(a) and j < len(b):
+        if a[i] <= b[j]:
+            result.append(a[i])
+            i += 1
+        else:
+            result.append(b[j])
+            j += 1
+
+    result.extend(a[i:])
+    result.extend(b[j:])
+
+    return result

--- a/tasks/task0031.py
+++ b/tasks/task0031.py
@@ -1,0 +1,39 @@
+"""
+Avito: Port ranges
+
+Дан диапазон портов `min` и `max`. Также есть список уже занятых портов `busy`.
+Нужно написать функцию, возвращающую все диапазоны свободных портов
+внутри `min` и `max`.
+
+Ввод:
+- min = 30000 - Минимально допустимый порт
+- max = 32000 - Максимально допустимый порт
+- busy = [30100, 30200, 31111] - Перечисление конкретных занятых портов
+
+Вывод:
+- [[30000, 30099], [30101, 30199], [30201, 31110], [31112, 32000]]
+
+Оценка:
+- N - длина списка busy
+- Оценка по времени - O(N log N) из-за сортировки (O(N), если busy уже отсортирован)
+- Оценка по памяти - O(N)
+"""
+
+from typing import List
+
+
+def solution(min_port: int, max_port: int, busy: List[int]) -> List[List[int]]:
+    result: List[List[int]] = []
+    start = min_port
+
+    for port in sorted(busy):
+        if port < min_port or port > max_port:
+            continue
+        if port > start:
+            result.append([start, port - 1])
+        start = port + 1
+
+    if start <= max_port:
+        result.append([start, max_port])
+
+    return result

--- a/tests/test_task0030.py
+++ b/tests/test_task0030.py
@@ -1,0 +1,37 @@
+import pytest
+
+from tasks.task0030 import solution
+
+
+@pytest.mark.parametrize(
+    "a, b, result",
+    [
+        (
+            [1, 2, 5],
+            [1, 2, 3, 4, 6],
+            [1, 1, 2, 2, 3, 4, 5, 6],
+        ),
+        (
+            [],
+            [1, 2, 3],
+            [1, 2, 3],
+        ),
+        (
+            [1, 2, 3],
+            [],
+            [1, 2, 3],
+        ),
+        (
+            [],
+            [],
+            [],
+        ),
+        (
+            [1, 4, 7],
+            [2, 3, 8],
+            [1, 2, 3, 4, 7, 8],
+        ),
+    ],
+)
+def test_task0030_solution(a, b, result):
+    assert solution(a, b) == result

--- a/tests/test_task0031.py
+++ b/tests/test_task0031.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tasks.task0031 import solution
+
+
+@pytest.mark.parametrize(
+    "min_port, max_port, busy, result",
+    [
+        (
+            30000,
+            32000,
+            [30100, 30200, 31111],
+            [[30000, 30099], [30101, 30199], [30201, 31110], [31112, 32000]],
+        ),
+        (
+            10,
+            12,
+            [10, 11, 12],
+            [],
+        ),
+        (
+            30000,
+            32000,
+            [],
+            [[30000, 32000]],
+        ),
+        (
+            30000,
+            32000,
+            [30000],
+            [[30001, 32000]],
+        ),
+        (
+            30000,
+            32000,
+            [32000],
+            [[30000, 31999]],
+        ),
+    ],
+)
+def test_task0031_solution(min_port, max_port, busy, result):
+    assert solution(min_port, max_port, busy) == result


### PR DESCRIPTION
Добавляет две задачи с собеседования Avito из issues.

## Что добавлено

- **task0030** — слияние двух отсортированных массивов методом двух указателей, O(M+N) по времени и памяти.
- **task0031** — поиск свободных диапазонов портов за один проход по отсортированному `busy`, O(N) по памяти.

Каждая задача оформлена в стиле существующих (docstring с условием + `solution()`) и покрыта параметризованными pytest-тестами, включая граничные случаи.

Closes #26
Closes #27